### PR TITLE
Update ex7_2_gan_cnn_mnist_tf.py

### DIFF
--- a/ex7_2_gan_cnn_mnist_tf.py
+++ b/ex7_2_gan_cnn_mnist_tf.py
@@ -88,13 +88,14 @@ class GAN(models.Sequential):
         z = self.get_z(ln)
         w = self.generator.predict(z, verbose=0)
         xw = np.concatenate((x, w))
-        y2 = [1] * ln + [0] * ln
+        y2 = np.array([1] * ln + [0] * ln)
         d_loss = self.discriminator.train_on_batch(xw, y2)
 
         # Second trial for training generator
         z = self.get_z(ln)
         self.discriminator.trainable = False
-        g_loss = self.train_on_batch(z, [1] * ln)
+        y2 = np.array([1] * ln)
+        g_loss = self.train_on_batch(z, y2)
         self.discriminator.trainable = True
 
         return d_loss, g_loss


### PR DESCRIPTION
y2의 자료형이 리스트로 지정되있어서 트레이닝 도중 .ndim 호출에 에러가 발생했습니다. numpy array로 재지정하였고, 에러가 해결됬습니다. 검토해주세요~

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-80-00fb3d16bd13> in <module>()
      9 args.n_train = 8
     10 
---> 11 train(args)

<ipython-input-79-e036bbe27fa6> in train(args)
     59             x = get_x(X_train, index, BATCH_SIZE)
     60 
---> 61             d_loss, g_loss = gan.train_both(x)
     62 
     63             d_loss_l.append(d_loss)

<ipython-input-78-5d036d9a03ee> in train_both(self, x)
     64         xw = np.concatenate((x, w))
     65         y2 = [1] * ln + [0] * ln
---> 66         d_loss = self.discriminator.train_on_batch(xw, (y2))
     67 
     68 

~/venv/GenP3/lib/python3.6/site-packages/keras/models.py in train_on_batch(self, x, y, class_weight, sample_weight)
   1067         return self.model.train_on_batch(x, y,
   1068                                          sample_weight=sample_weight,
-> 1069                                          class_weight=class_weight)
   1070 
   1071     def test_on_batch(self, x, y,

~/venv/GenP3/lib/python3.6/site-packages/keras/engine/training.py in train_on_batch(self, x, y, sample_weight, class_weight)
   1841             sample_weight=sample_weight,
   1842             class_weight=class_weight,
-> 1843             check_batch_axis=True)
   1844         if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
   1845             ins = x + y + sample_weights + [1.]

~/venv/GenP3/lib/python3.6/site-packages/keras/engine/training.py in _standardize_user_data(self, x, y, sample_weight, class_weight, check_batch_axis, batch_size)
   1428                                     output_shapes,
   1429                                     check_batch_axis=False,
-> 1430                                     exception_prefix='target')
   1431         sample_weights = _standardize_sample_weights(sample_weight,
   1432                                                      self._feed_output_names)

~/venv/GenP3/lib/python3.6/site-packages/keras/engine/training.py in _standardize_input_data(data, names, shapes, check_batch_axis, exception_prefix)
     68     elif isinstance(data, list):
     69         data = [x.values if x.__class__.__name__ == 'DataFrame' else x for x in data]
---> 70         data = [np.expand_dims(x, 1) if x is not None and x.ndim == 1 else x for x in data]
     71     else:
     72         data = data.values if data.__class__.__name__ == 'DataFrame' else data

~/venv/GenP3/lib/python3.6/site-packages/keras/engine/training.py in <listcomp>(.0)
     68     elif isinstance(data, list):
     69         data = [x.values if x.__class__.__name__ == 'DataFrame' else x for x in data]
---> 70         data = [np.expand_dims(x, 1) if x is not None and x.ndim == 1 else x for x in data]
     71     else:
     72         data = data.values if data.__class__.__name__ == 'DataFrame' else data

AttributeError: 'int' object has no attribute 'ndim'
```